### PR TITLE
Update HP modification to use a postfix on GetTotalFoodValue instead of transpile

### DIFF
--- a/Vitality/Vitality.cs
+++ b/Vitality/Vitality.cs
@@ -18,7 +18,7 @@ namespace Vitality;
 public class Vitality : BaseUnityPlugin
 {
 	private const string ModName = "Vitality";
-	private const string ModVersion = "1.1.2";
+	private const string ModVersion = "1.1.1";
 	private const string ModGUID = "org.bepinex.plugins.vitality";
 
 	private static readonly ConfigSync configSync = new(ModName) { DisplayName = ModName, CurrentVersion = ModVersion, MinimumRequiredVersion = ModVersion };
@@ -90,14 +90,15 @@ public class Vitality : BaseUnityPlugin
 
 	[HarmonyPatch(typeof(Player), nameof(Player.GetTotalFoodValue))]
 	private class IncreaseBaseHealth
-    {
+	{
+		[UsedImplicitly]
 		[HarmonyPriority(Priority.LowerThanNormal)]
 		private static void Postfix(Player __instance, ref float hp)
 		{
 			var baseHp = __instance.m_baseHP;
 
-            // Base HP is already factored in by the GetTotalFoodValue call, so don't add 1 to the multiplier.
-            var multiplier = (bonusHPMultiplier.Value - 1) * __instance.GetSkillFactor("Vitality");
+			// Base HP is already factored in by the GetTotalFoodValue call, so don't add 1 to the multiplier.
+			var multiplier = (bonusHPMultiplier.Value - 1) * __instance.GetSkillFactor("Vitality");
 
 			hp += multiplier * baseHp;
 		}

--- a/Vitality/Vitality.cs
+++ b/Vitality/Vitality.cs
@@ -95,7 +95,7 @@ public class Vitality : BaseUnityPlugin
 		[HarmonyPriority(Priority.LowerThanNormal)]
 		private static void Postfix(Player __instance, ref float hp)
 		{
-			var baseHp = __instance.m_baseHP;
+			var baseHp = __instance.GetBaseFoodHP();
 
 			// Base HP is already factored in by the GetTotalFoodValue call, so don't add 1 to the multiplier.
 			var multiplier = (bonusHPMultiplier.Value - 1) * __instance.GetSkillFactor("Vitality");


### PR DESCRIPTION
Fixes #2

I was having the same issue that the individual in the reported issue was having, even with only this mod installed and nothing else. I'm not sure why the current logic isn't working, but I'm guessing something changed with the Mistlands update that caused this logic to no longer work.

I've reworked the logic to add the extra health at the end of the `GetTotalFoodValue` function. It's still based off the defined base health of the player, as determined by the `GetBaseFoodHP` function.